### PR TITLE
Personal/kotynek/bugfix 27941 maintain alias membership in delete operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <groupId>eu.bcvsolutions.idm.connector</groupId>
   <artifactId>ldap-connector</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
 
   <name>LDAP connector</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <groupId>eu.bcvsolutions.idm.connector</groupId>
   <artifactId>ldap-connector</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <name>LDAP connector</name>
 

--- a/src/main/java/net/tirasa/connid/bundles/ldap/commons/GroupHelper.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/commons/GroupHelper.java
@@ -203,6 +203,13 @@ public class GroupHelper {
             addMemberToGroup(getAliasGroupMemberAttribute(), aliasRefAttr, groupDN);
         }
     }
+
+    public void removeAliasGroupMembership(Set<GroupMembership> memberships) {
+        log.ok("Removing Alias group memberships {0}", memberships);
+        for (GroupMembership membership : memberships) {
+            removeMemberFromGroup(getAliasGroupMemberAttribute(), membership.getMemberRef(), membership.getGroupDN());
+        }
+    }
     
     public void modifyAliasGroupMemberships(Modification<GroupMembership> mod) {
 		log.ok("Modifying ALIAS group memberships: removing {0}, adding {1}", mod.getRemoved(), mod.getAdded());

--- a/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapDelete.java
+++ b/src/main/java/net/tirasa/connid/bundles/ldap/modify/LdapDelete.java
@@ -30,6 +30,7 @@ import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.Uid;
 import net.tirasa.connid.bundles.ldap.LdapConnection;
+import net.tirasa.connid.bundles.ldap.commons.GroupHelper;
 import net.tirasa.connid.bundles.ldap.commons.LdapModifyOperation;
 import net.tirasa.connid.bundles.ldap.commons.GroupHelper.GroupMembership;
 import net.tirasa.connid.bundles.ldap.search.LdapSearches;
@@ -58,6 +59,12 @@ public class LdapDelete extends LdapModifyOperation {
             PosixGroupMember posixMember = new PosixGroupMember(entryDN);
             Set<GroupMembership> memberships = posixMember.getPosixGroupMemberships();
             groupHelper.removePosixGroupMemberships(memberships);
+        }
+
+        if (conn.getConfiguration().isMaintainAliasGroupMembership()) {
+            AliasGroupMember aliasMember = new AliasGroupMember(entryDN);
+            Set<GroupMembership> memberships = aliasMember.getAliasGroupMemberships();
+            groupHelper.removeAliasGroupMembership(memberships);
         }
 
         try {


### PR DESCRIPTION
[#27941](https://redmine.bcvsolutions.eu/issues/27941) Modify the LDAP connector to remove the user's address from the mail group when deleting the user